### PR TITLE
Fix flask of crimson tears

### DIFF
--- a/src/erdb/table/tools.py
+++ b/src/erdb/table/tools.py
@@ -29,7 +29,7 @@ class ToolTableSpec(TableSpecContext):
     main_param_retriever = ParamDictRetriever("EquipParamGoods", ItemIDFlag.GOODS)
 
     predicates: list[RowPredicate] = [
-        lambda row: 1 <= row["sortId"].as_int < 999999,
+        lambda row: 0 <= row["sortId"].as_int < 999999,
         lambda row: row["sortGroupId"].as_int != GoodsSortGroupID.GESTURES,
         lambda row: row["goodsType"] in [GoodsType.NORMAL_ITEM, GoodsType.REMEMBRANCE, GoodsType.WONDROUS_PHYSICK_TEAR, GoodsType.GREAT_RUNE],
         lambda row: not _is_note_item(row.name),

--- a/src/erdb/typing/categories.py
+++ b/src/erdb/typing/categories.py
@@ -224,6 +224,7 @@ class ToolCategory(_CategoryBase):
             G.GROUP_1: T.ESSENTIAL,
             G.GROUP_2: T.EDIBLE,
             G.GROUP_3: T.POT,
+            G.ANY: T.POT,
             G.GROUP_4: T.AROMATIC,
             G.GROUP_5: T.THROWABLE,
             G.GROUP_6: T.OFFENSIVE,


### PR DESCRIPTION
Fix flask of crimson tears being excluded.
I only ran `generate tools` and `icons tools`.

Here is the diff for both:
https://github.com/EthanShoeDev/elden-ring-compass/pull/2/commits/4bc8708f567a5355ef9a474053c4e149c149831c

Related: https://github.com/EldenRingDatabase/erdb/issues/3